### PR TITLE
Allow Multibundle Uploads Using ndjson Files

### DIFF
--- a/util/fileAnalyzer.go
+++ b/util/fileAnalyzer.go
@@ -1,0 +1,84 @@
+package util
+
+import (
+	"io"
+)
+
+// Size of the buffer used for calculating file chunks.
+const chunksCalculationBufferSizeBytes = 4096
+
+// FileChunk describes a chunk within a file with its starting position and end
+// position in bytes. Both are given as bytes counted from the file's beginning.
+// Also carries information about the chunk number (i.e. its order position)
+// within the file.
+type FileChunk struct {
+	ChunkNumber int
+	StartBytes  int64
+	EndBytes    int64
+}
+
+// FileChunkCalculationResult represents a single result of a file chunk calculation.
+// Carries information about a FileChunk and additional error information.
+// A FileChunk can still hold valuable information even in the presence of an
+// error such as the chunk number.
+type FileChunkCalculationResult struct {
+	FileChunk FileChunk
+	Err       error
+}
+
+// CalculateFileChunks calculates all chunks of r that are delimited by delimiter.
+// r is read in a streamed fashion.
+// Results will be published on a res channel as they appear when reading r.
+// Closes the result channel as soon as r is exhaustively read.
+func CalculateFileChunks(r io.Reader, delimiter byte, res chan<- FileChunkCalculationResult) {
+	var lastSeenDelimiterTokenOffsetBytes int64 = 0
+	alreadyReadBytes := int64(0)
+	chunkNumber := 0
+	buf := make([]byte, 0, chunksCalculationBufferSizeBytes)
+	for {
+		n, err := r.Read(buf[:cap(buf)])
+		buf = buf[:n]
+		if n == 0 {
+			if err == nil {
+				continue
+			}
+			if err == io.EOF {
+				// For when r does not end with the delimiter.
+				if alreadyReadBytes > lastSeenDelimiterTokenOffsetBytes {
+					res <- FileChunkCalculationResult{
+						FileChunk: FileChunk{
+							ChunkNumber: chunkNumber + 1,
+							StartBytes:  lastSeenDelimiterTokenOffsetBytes,
+							EndBytes:    alreadyReadBytes,
+						},
+					}
+				}
+
+				close(res)
+				break
+			}
+			res <- FileChunkCalculationResult{
+				FileChunk: FileChunk{
+					ChunkNumber: chunkNumber,
+				},
+				Err: err,
+			}
+		}
+
+		for idx, b := range buf {
+			if b == delimiter {
+				chunkNumber++
+				res <- FileChunkCalculationResult{
+					FileChunk: FileChunk{
+						ChunkNumber: chunkNumber,
+						StartBytes:  lastSeenDelimiterTokenOffsetBytes,
+						EndBytes:    alreadyReadBytes + int64(idx),
+					},
+				}
+				lastSeenDelimiterTokenOffsetBytes = alreadyReadBytes + int64(idx) + 1
+			}
+		}
+
+		alreadyReadBytes += int64(n)
+	}
+}

--- a/util/fileAnalyzer_test.go
+++ b/util/fileAnalyzer_test.go
@@ -1,0 +1,97 @@
+package util
+
+import (
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestCalculateFileChunks(t *testing.T) {
+	res := make(chan FileChunkCalculationResult)
+	reader := strings.NewReader("A simple\ntest case\n")
+
+	resultPool := make([]FileChunkCalculationResult, 0, 2)
+	go CalculateFileChunks(reader, byte('\n'), res)
+
+	for chunk := range res {
+		resultPool = append(resultPool, chunk)
+	}
+
+	assert.Equal(t, 2, len(resultPool))
+	assert.Equal(t, int64(0), resultPool[0].FileChunk.StartBytes)
+	assert.Equal(t, int64(8), resultPool[0].FileChunk.EndBytes)
+	assert.Equal(t, int64(9), resultPool[1].FileChunk.StartBytes)
+	assert.Equal(t, int64(18), resultPool[1].FileChunk.EndBytes)
+}
+
+func TestCalculateFileChunksWithoutClosingDelimiter(t *testing.T) {
+	res := make(chan FileChunkCalculationResult)
+	reader := strings.NewReader("No closing\nnewline")
+
+	resultPool := make([]FileChunkCalculationResult, 0, 2)
+	go CalculateFileChunks(reader, byte('\n'), res)
+
+	for chunk := range res {
+		resultPool = append(resultPool, chunk)
+	}
+
+	assert.Equal(t, 2, len(resultPool))
+	assert.Equal(t, int64(0), resultPool[0].FileChunk.StartBytes)
+	assert.Equal(t, int64(10), resultPool[0].FileChunk.EndBytes)
+	assert.Equal(t, int64(11), resultPool[1].FileChunk.StartBytes)
+	assert.Equal(t, int64(18), resultPool[1].FileChunk.EndBytes)
+}
+
+func TestCalculateFileChunksWithSingleChunkWithClosingDelimiter(t *testing.T) {
+	res := make(chan FileChunkCalculationResult)
+	reader := strings.NewReader("Closing delimiter\n")
+
+	resultPool := make([]FileChunkCalculationResult, 0, 1)
+	go CalculateFileChunks(reader, byte('\n'), res)
+
+	for chunk := range res {
+		resultPool = append(resultPool, chunk)
+	}
+
+	assert.Equal(t, 1, len(resultPool))
+	assert.Equal(t, int64(0), resultPool[0].FileChunk.StartBytes)
+	assert.Equal(t, reader.Size()-1, resultPool[0].FileChunk.EndBytes)
+}
+
+func TestCalculateFileChunksWithSingleChunkWithoutClosingDelimiter(t *testing.T) {
+	res := make(chan FileChunkCalculationResult)
+	reader := strings.NewReader("No closing delimiter")
+
+	resultPool := make([]FileChunkCalculationResult, 0, 1)
+	go CalculateFileChunks(reader, byte('\n'), res)
+
+	for chunk := range res {
+		resultPool = append(resultPool, chunk)
+	}
+
+	assert.Equal(t, 1, len(resultPool))
+	assert.Equal(t, int64(0), resultPool[0].FileChunk.StartBytes)
+	assert.Equal(t, reader.Size(), resultPool[0].FileChunk.EndBytes)
+}
+
+func TestCalculateFileChunksMultipleConsecutiveDelimiters(t *testing.T) {
+	res := make(chan FileChunkCalculationResult)
+	reader := strings.NewReader("Multiple\n\n\nDelimiters")
+
+	resultPool := make([]FileChunkCalculationResult, 0, 4)
+	go CalculateFileChunks(reader, byte('\n'), res)
+
+	for chunk := range res {
+		resultPool = append(resultPool, chunk)
+	}
+
+	assert.Equal(t, 4, len(resultPool))
+	assert.Equal(t, int64(0), resultPool[0].FileChunk.StartBytes)
+	assert.Equal(t, int64(8), resultPool[0].FileChunk.EndBytes)
+	assert.Equal(t, int64(9), resultPool[1].FileChunk.StartBytes)
+	assert.Equal(t, int64(9), resultPool[1].FileChunk.EndBytes)
+	assert.Equal(t, int64(10), resultPool[2].FileChunk.StartBytes)
+	assert.Equal(t, int64(10), resultPool[2].FileChunk.EndBytes)
+	assert.Equal(t, int64(11), resultPool[3].FileChunk.StartBytes)
+	assert.Equal(t, reader.Size(), resultPool[3].FileChunk.EndBytes)
+}


### PR DESCRIPTION
This implements a functionality that allows uploading files that comprise multiple FHIR bundles. This is done using the [ndjson](https://github.com/ndjson/ndjson-spec) format.

Changes the upload workflow to a producer/consumer workflow. Bundles that shall be uploaded are stored within an upload queue with a capacity equal to the concurrency value set by the user. There is a single producer for each file type (files comprising a single FHIR bundle, files comprising multiple FHIR bundles). The consumer is a single process firing up upload routines to a FHIR server as new bundle information are present within the queue.

Also implements a progress bar that can be used whenever the total size is not known upfront. In our case we want to display how many bundles out of all of them have been uploaded already. Since we do not consume the entire file if it is expected to hold multiple FHIR bundles (uses the `.ndjson` extension) we do not know how many bundles are in there. Consuming the whole file would blow up RAM usage since these files tend to be quite large so this is not an option. Instead the total number of bundles is adjusted dynamically as they are encountered.