### PR TITLE
Add Flag to Disable TLS Security Checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Available Commands:
 
 Flags:
   -h, --help              help for blazectl
+  -k, --insecure          allow insecure server connections when using SSL
       --no-progress       don't show progress bar
       --password string   password information for basic authentication
       --user string       user information for basic authentication

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ import (
 )
 
 var server string
+var disableTlsSecurity bool
 var basicAuthUser string
 var basicAuthPassword string
 var noProgress bool
@@ -36,7 +37,11 @@ func createClient() error {
 	}
 
 	clientAuth := fhir.ClientAuth{BasicAuthUser: basicAuthUser, BasicAuthPassword: basicAuthPassword}
-	client = fhir.NewClient(*fhirServerBaseUrl, clientAuth)
+	if disableTlsSecurity {
+		client = fhir.NewClientInsecure(*fhirServerBaseUrl, clientAuth)
+	} else {
+		client = fhir.NewClient(*fhirServerBaseUrl, clientAuth)
+	}
 	return nil
 }
 
@@ -60,6 +65,7 @@ func Execute() {
 }
 
 func init() {
+	rootCmd.PersistentFlags().BoolVarP(&disableTlsSecurity, "insecure", "k", false, "allow insecure server connections when using SSL")
 	rootCmd.PersistentFlags().StringVar(&basicAuthUser, "user", "", "user information for basic authentication")
 	rootCmd.PersistentFlags().StringVar(&basicAuthPassword, "password", "", "password information for basic authentication")
 	rootCmd.PersistentFlags().BoolVarP(&noProgress, "no-progress", "", false, "don't show progress bar")

--- a/fhir/client.go
+++ b/fhir/client.go
@@ -41,7 +41,19 @@ type ClientAuth struct {
 	BasicAuthPassword string
 }
 
+// NewClient creates a new Client with the given base URL and ClientAuth configuration.
 func NewClient(fhirServerBaseUrl url.URL, auth ClientAuth) *Client {
+	return createClient(fhirServerBaseUrl, auth, false)
+}
+
+// NewClientInsecure creates a new Client as NewClient does but disables TLS security checks. I.e. the client will
+// accept any connection to a servers without verifying its certificate.
+// Use this with great caution as it opens up man-in-the-middle attacks.
+func NewClientInsecure(fhirServerBaseUrl url.URL, auth ClientAuth) *Client {
+	return createClient(fhirServerBaseUrl, auth, true)
+}
+
+func createClient(fhirServerBaseUrl url.URL, auth ClientAuth, insecure bool) *Client {
 	// Ensures subsequent calls to ResolveReference do not overwrite the path of the base URL.
 	// To avoid this a trailing slash is required.
 	if len(fhirServerBaseUrl.Path) > 0 && !strings.HasSuffix(fhirServerBaseUrl.Path, "/") {
@@ -52,6 +64,7 @@ func NewClient(fhirServerBaseUrl url.URL, auth ClientAuth) *Client {
 	t.MaxIdleConns = 100
 	t.MaxConnsPerHost = 100
 	t.MaxIdleConnsPerHost = 100
+	t.TLSClientConfig.InsecureSkipVerify = insecure
 
 	return &Client{
 		httpClient: http.Client{Transport: t},


### PR DESCRIPTION
Adds a flag (--insecure / -k) to allow users to disable TLS security checks.
With this change, connections to servers with self-signed certificates are
possible without the need for putting them in a trust chain.

If you want to be able to load certificates into a trust chain and configure the client accordingly, then please let me know and we change adjust our solution.

Resolves #22 