### PR TITLE
Fix Limit of 100 Polls

### DIFF
--- a/cmd/countResources_test.go
+++ b/cmd/countResources_test.go
@@ -28,8 +28,8 @@ import (
 func TestFetchResourcesTotal(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "application/fhir+json", r.Header.Get("Accept"))
-		assert.Equal(t, "application/fhir+json", r.Header.Get("Content-Type"))
+		assert.Equal(t, fhir.MediaTypeFhirJson, r.Header.Get(fhir.HeaderAccept))
+		assert.Equal(t, fhir.MediaTypeFhirJson, r.Header.Get(fhir.HeaderContentType))
 		defer r.Body.Close()
 		bundle, err := fhir.ReadBundle(r.Body)
 		if err != nil {


### PR DESCRIPTION
Async polling had the problem that no more than 100 polls were done before blazectl got stuck and had to be killed. The problem was caused by not reading the HTTP responses completely. I did this and moved the function PollAsyncStatus into the fhir package so that it also can be used from the compact command.