### PR TITLE
Improve Download JSON Parsing Performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+lint:
+	golangci-lint run
+
+test:
+	go test ./...
+
+.PHONY: lint test

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -17,12 +17,7 @@ package cmd
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"fmt"
-	"github.com/samply/blazectl/fhir"
-	"github.com/samply/blazectl/util"
-	fm "github.com/samply/golang-fhir-models/fhir-models/fhir"
-	"github.com/spf13/cobra"
 	"io"
 	"net/http"
 	"net/http/httptrace"
@@ -31,6 +26,12 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/goccy/go-json"
+	"github.com/samply/blazectl/fhir"
+	"github.com/samply/blazectl/util"
+	fm "github.com/samply/golang-fhir-models/fhir-models/fhir"
+	"github.com/spf13/cobra"
 )
 
 var outputFile string
@@ -508,8 +509,13 @@ func createOutputFileOrDie(filepath string) *os.File {
 	return outputFile
 }
 
+type bundleEntry struct {
+	Resource json.RawMessage       `bson:"resource,omitempty" json:"resource,omitempty"`
+	Search   *fm.BundleEntrySearch `bson:"search,omitempty" json:"search,omitempty"`
+}
+
 type entryBundle struct {
-	Entry []fm.BundleEntry `bson:"entry,omitempty" json:"entry,omitempty"`
+	Entry []bundleEntry `bson:"entry,omitempty" json:"entry,omitempty"`
 }
 
 // writeOutResources takes a raw set of FHIR bundle entries and writes the resource part of each of them to the given

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24
 toolchain go1.24.6
 
 require (
+	github.com/goccy/go-json v0.10.5
 	github.com/goccy/go-yaml v1.18.0
 	github.com/google/uuid v1.6.0
 	github.com/samply/golang-fhir-models/fhir-models v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat6
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
+github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
The standard encoding/json lib is quite slow because it uses reflection. There are some third party drop-in replacements like https://github.com/json-iterator/go or https://github.com/goccy/go-json. I decided to go with https://github.com/goccy/go-json because it's actively maintained.

The speedup is about 2x. The download of 1 million cached patient resources finishes in 11 seconds compared to 25 seconds before. Other downloads of real FHIR searches or uncached resources is not faster, but the CPU usage of blazectl is about half as much.