### PR TITLE
Trim Contents of Query File

### DIFF
--- a/util/query.go
+++ b/util/query.go
@@ -29,7 +29,7 @@ func ReadQueryFromFile(filename string) (url.Values, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error while reading file: %s: %w", filename, err)
 	}
-	q, err := url.ParseQuery(string(b))
+	q, err := url.ParseQuery(strings.TrimSpace(string(b)))
 	if err != nil {
 		return nil, fmt.Errorf("error while parsing query: %w", err)
 	}

--- a/util/query_test.go
+++ b/util/query_test.go
@@ -15,19 +15,33 @@
 package util
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestReadQueryFromFile(t *testing.T) {
 	tmpDir := t.TempDir()
-	queryFile := filepath.Join(tmpDir, "test.query")
-	assert.NoError(t, os.WriteFile(queryFile, []byte("foo=bar"), 0644))
 
-	q, err := ReadQueryFromFile("@" + queryFile)
+	t.Run("test query", func(t *testing.T) {
+		queryFile := filepath.Join(tmpDir, "test.query")
+		assert.NoError(t, os.WriteFile(queryFile, []byte("foo=bar"), 0644))
 
-	assert.NoError(t, err)
-	assert.Equal(t, "bar", q.Get("foo"))
+		q, err := ReadQueryFromFile("@" + queryFile)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "bar", q.Get("foo"))
+	})
+
+	t.Run("test query with trailing newline in the file", func(t *testing.T) {
+		queryFile := filepath.Join(tmpDir, "test.query")
+		assert.NoError(t, os.WriteFile(queryFile, []byte("foo=bar\n"), 0644))
+
+		q, err := ReadQueryFromFile("@" + queryFile)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "bar", q.Get("foo"))
+	})
 }


### PR DESCRIPTION
I had problems with a trailing _count=1000, which was send with the trailing newline from the file.