### PR TITLE
feat: read user and password from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,21 @@ Flags:
   -h, --help                           help for blazectl
   -k, --insecure                       allow insecure server connections when using SSL
       --no-progress                    don't show progress bar
-      --password string                password information for basic authentication
+      --password string                password information for basic authentication (env: BLAZECTL_PASSWORD)
       --token string                   bearer token for authentication
-      --user string                    user information for basic authentication
+      --user string                    user information for basic authentication (env: BLAZECTL_USER)
   -v, --version                        version for blazectl
 
 Use "blazectl [command] --help" for more information about a command.
+```
+
+### Environment Variables
+
+To avoid visible credentials in the process list (e.g. by `ps`) by passing username and password on the command line, you can also provide them via environment variables:
+```sh
+export BLAZECTL_USER="myuser"
+export BLAZECTL_PASSWORD="myS3cr3T"
+blazectl upload --server http://localhost:8080/fhir my/bundles
 ```
 
 ### Upload

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,15 @@ func createClient() error {
 }
 
 func clientAuth() fhir.Auth {
+	// check for environment variables
+	var envUser = os.Getenv("BLAZECTL_USER")
+	if basicAuthUser == "" && envUser != "" {
+		basicAuthUser = envUser
+	}
+	var envPassword = os.Getenv("BLAZECTL_PASSWORD")
+	if basicAuthPassword == "" && envPassword != "" {
+		basicAuthPassword = envPassword
+	}
 	if basicAuthUser != "" && basicAuthPassword != "" {
 		return fhir.BasicAuth{User: basicAuthUser, Password: basicAuthPassword}
 	} else if bearerToken != "" {
@@ -85,8 +94,8 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&disableTlsSecurity, "insecure", "k", false, "allow insecure server connections when using SSL")
 	rootCmd.PersistentFlags().StringVar(&caCert, "certificate-authority", "", "path to a cert file for the certificate authority")
-	rootCmd.PersistentFlags().StringVar(&basicAuthUser, "user", "", "user information for basic authentication")
-	rootCmd.PersistentFlags().StringVar(&basicAuthPassword, "password", "", "password information for basic authentication")
+	rootCmd.PersistentFlags().StringVar(&basicAuthUser, "user", "", "user information for basic authentication (env: BLAZECTL_USER)")
+	rootCmd.PersistentFlags().StringVar(&basicAuthPassword, "password", "", "password information for basic authentication (env: BLAZECTL_PASSWORD)")
 	rootCmd.PersistentFlags().StringVar(&bearerToken, "token", "", "bearer token for authentication")
 	rootCmd.PersistentFlags().BoolVarP(&noProgress, "no-progress", "", false, "don't show progress bar")
 }


### PR DESCRIPTION
added import of environment variables BLAZECTL_USER and BLAZECTL_USER to avoid visible credentials in process list